### PR TITLE
MapStruct auf Version 1.1 updaten

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ This project defines a common api for Java object mapping. Similiar to SLF4J map
 
 The only compile time dependency you need to define is
 
-
-    compile 'ch.silviowangler.map4j:map4j-api:0.0.2'
+    compile 'ch.silviowangler.map4j:map4j-api:0.0.6'
 
 or if you automatically would like to stay always on the latest version define
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,7 @@ subprojects {
     apply plugin: 'maven-publish'
     apply plugin: 'com.jfrog.bintray'
 
-    version = '0.0.7.6'
-    sourceCompatibility = org.gradle.api.JavaVersion.VERSION_1_8
+    version = '0.0.6'
 
     dependencies {
         // The production code uses the SLF4J logging API at compile time
@@ -66,10 +65,8 @@ subprojects {
     }
 
     bintray {
-        //user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
-        //key = project.hasProperty('bintrayKey') ? project.property('bintrayKey') : System.getenv('BINTRAY_API_KEY')
-        user = 'stefanloosli'
-        key = '101ee22e8faa08ca867228c0f09e4ded0b520659'
+        user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
+        key = project.hasProperty('bintrayKey') ? project.property('bintrayKey') : System.getenv('BINTRAY_API_KEY')
         publications = ['JavaPublication']
         pkg {
             repo = 'releases'

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import java.time.LocalDate
+import java.time.LocalDateTime
+
 buildscript {
     repositories {
         jcenter()
@@ -22,8 +25,8 @@ subprojects {
     apply plugin: 'maven-publish'
     apply plugin: 'com.jfrog.bintray'
 
-    version = '0.0.6'
-    sourceCompatibility = org.gradle.api.JavaVersion.VERSION_1_7
+    version = '0.0.7.6'
+    sourceCompatibility = org.gradle.api.JavaVersion.VERSION_1_8
 
     dependencies {
         // The production code uses the SLF4J logging API at compile time
@@ -55,7 +58,7 @@ subprojects {
                     classifier "sources"
                 }
 
-                groupId 'ch.silviowangler.map4j'
+                groupId 'ch.stefanloosli.map4j'
                 artifactId project.name
                 version project.version
             }
@@ -63,21 +66,23 @@ subprojects {
     }
 
     bintray {
-        user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
-        key = project.hasProperty('bintrayKey') ? project.property('bintrayKey') : System.getenv('BINTRAY_API_KEY')
+        //user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
+        //key = project.hasProperty('bintrayKey') ? project.property('bintrayKey') : System.getenv('BINTRAY_API_KEY')
+        user = 'stefanloosli'
+        key = '101ee22e8faa08ca867228c0f09e4ded0b520659'
         publications = ['JavaPublication']
         pkg {
             repo = 'releases'
             name = 'map4j'
             licenses = ['Apache-2.0']
-            vcsUrl = 'https://github.com/saw303/map4j.git'
+            vcsUrl = 'https://github.com/loosli/map4j.git'
             labels = ['orika', 'mapper', 'dozer']
             publicDownloadNumbers = true
             version {
                 name = project.version
                 desc = 'map4j'
                 vcsTag = project.version
-                released = new Date()
+                //released = LocalDateTime.now()
             }
         }
     }
@@ -89,7 +94,7 @@ subprojects {
         from("${rootProject.projectDir}") {
             include "LICENSE.txt"
             into "META-INF"
-            expand(dateOfYear: new Date().format('yyyy'))
+            expand(dateOfYear: LocalDate.now().getYear())
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ subprojects {
                     classifier "sources"
                 }
 
-                groupId 'ch.stefanloosli.map4j'
+                groupId 'ch.silviowangler.map4j'
                 artifactId project.name
                 version project.version
             }
@@ -72,7 +72,7 @@ subprojects {
             repo = 'releases'
             name = 'map4j'
             licenses = ['Apache-2.0']
-            vcsUrl = 'https://github.com/loosli/map4j.git'
+            vcsUrl = 'https://github.com/saw303/map4j.git'
             labels = ['orika', 'mapper', 'dozer']
             publicDownloadNumbers = true
             version {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ artifactoryPluginVersion=1.6
 
 
 # Libraries
-mapStructVersion=1.0.0.Final
+mapStructVersion=1.1.0.Final
 dozerVersion=5.5.1
 orikaVersion=1.4.6
 slf4jVersion=1.7.12

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.2.1-all.zip

--- a/map4j-mapstruct/mapstruct-api/src/main/java/ch/silviowangler/map4j/mapstruct/InverseBaseMapper.java
+++ b/map4j-mapstruct/mapstruct-api/src/main/java/ch/silviowangler/map4j/mapstruct/InverseBaseMapper.java
@@ -1,0 +1,16 @@
+package ch.silviowangler.map4j.mapstruct;
+
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+/**
+ * Created by Silvio Wangler on 18/04/16.
+ */
+public interface InverseBaseMapper<S, T> extends BaseMapper<S, T>{
+
+    S createFromSourceInverse(T source);
+
+    default void updateFromSourceInverse(T source, S target) {
+        throw new NotImplementedException();
+    }
+
+}

--- a/map4j-mapstruct/mapstruct-bp/build.gradle
+++ b/map4j-mapstruct/mapstruct-bp/build.gradle
@@ -3,5 +3,5 @@ dependencies {
 
     compile project(":mapstruct-api")
 }
-
+sourceCompatibility = org.gradle.api.JavaVersion.VERSION_1_7
 apply from: "${rootDir}/gradle/mapstruct.gradle"

--- a/map4j-mapstruct/mapstruct/build.gradle
+++ b/map4j-mapstruct/mapstruct/build.gradle
@@ -1,5 +1,3 @@
-sourceCompatibility = org.gradle.api.JavaVersion.VERSION_1_8
-
 dependencies {
     compile "org.mapstruct:mapstruct-jdk8:${mapStructVersion}"
     compile project(":mapstruct-api")

--- a/map4j-mapstruct/mapstruct/src/main/java/ch/silviowangler/map4j/mapstruct/MapStructMapper.java
+++ b/map4j-mapstruct/mapstruct/src/main/java/ch/silviowangler/map4j/mapstruct/MapStructMapper.java
@@ -3,12 +3,12 @@ package ch.silviowangler.map4j.mapstruct;
 import java.util.function.BiFunction;
 
 import ch.silviowangler.map4j.Mapper;
+import org.mapstruct.factory.Mappers;
 
 /**
  * Created by Silvio Wangler on 14/04/16.
  */
 public class MapStructMapper implements Mapper {
-
 
     private final MapperRegistry registry;
 
@@ -18,12 +18,30 @@ public class MapStructMapper implements Mapper {
 
     @Override
     public <T> T map(Object source, Class<T> targetClass) {
+        BaseMapper baseMapper = registry.resolveBaseMapper(source.getClass(), targetClass);
+        if(baseMapper != null) {
+            return (T) baseMapper.createFromSource(source);
+        }
+        InverseBaseMapper inverseBaseMapper = registry.resolveInverseMapper(source.getClass(), targetClass);
+        if(inverseBaseMapper != null) {
+            return (T) inverseBaseMapper.createFromSourceInverse(source);
+        }
         BiFunction function = registry.resolveConsumer(source.getClass(), targetClass);
         return (T) function.apply(source, null);
     }
 
     @Override
     public <T> void map(Object source, T target) {
+        BaseMapper baseMapper = registry.resolveBaseMapper(source.getClass(), target.getClass());
+        if(baseMapper != null) {
+            baseMapper.updateFromSource(source, target);
+            return;
+        }
+        InverseBaseMapper inverseBaseMapper = registry.resolveInverseMapper(source.getClass(), target.getClass());
+        if(inverseBaseMapper != null) {
+            inverseBaseMapper.updateFromSourceInverse(source, target);
+            return;
+        }
         BiFunction function = registry.resolveConsumer(source.getClass(), target.getClass());
         function.apply(source, target);
     }

--- a/map4j-mapstruct/mapstruct/src/main/java/ch/silviowangler/map4j/mapstruct/MapStructMapper.java
+++ b/map4j-mapstruct/mapstruct/src/main/java/ch/silviowangler/map4j/mapstruct/MapStructMapper.java
@@ -16,6 +16,14 @@ public class MapStructMapper implements Mapper {
         this.registry = registry;
     }
 
+    /**
+     * Maps an object to another object with the registered MapStruct Mapper.
+     * The return object will be created within this method
+     * @param source source map object instance
+     * @param targetClass target class
+     * @param <T> the type of the return instance object
+     * @return the mapped object
+     */
     @Override
     public <T> T map(Object source, Class<T> targetClass) {
         BaseMapper baseMapper = registry.resolveBaseMapper(source.getClass(), targetClass);
@@ -27,9 +35,20 @@ public class MapStructMapper implements Mapper {
             return (T) inverseBaseMapper.createFromSourceInverse(source);
         }
         BiFunction function = registry.resolveConsumer(source.getClass(), targetClass);
-        return (T) function.apply(source, null);
+        if(function != null) {
+            return (T) function.apply(source, null);
+        }
+        throw new NoSuchMappingException ("No such mapping for source class " + source.getClass().getSimpleName () + " and target class "
+                + targetClass.getSimpleName (), source.getClass(), targetClass);
     }
 
+    /**
+     * Maps an object to another object with the registered MapStruct Mapper.
+     * The target object will be update by the source objects attributes
+     * @param source source map object instance
+     * @param target target class
+     * @param <T> the type of the target object
+     */
     @Override
     public <T> void map(Object source, T target) {
         BaseMapper baseMapper = registry.resolveBaseMapper(source.getClass(), target.getClass());
@@ -43,6 +62,12 @@ public class MapStructMapper implements Mapper {
             return;
         }
         BiFunction function = registry.resolveConsumer(source.getClass(), target.getClass());
-        function.apply(source, target);
+        if(function != null) {
+            function.apply(source, target);
+            return;
+        }
+        throw new NoSuchMappingException ("No such mapping for source class " + source.getClass().getSimpleName () + " and target class "
+                + target.getClass().getSimpleName (), source.getClass(), target.getClass());
+
     }
 }

--- a/map4j-mapstruct/mapstruct/src/main/java/ch/silviowangler/map4j/mapstruct/MapperRegistry.java
+++ b/map4j-mapstruct/mapstruct/src/main/java/ch/silviowangler/map4j/mapstruct/MapperRegistry.java
@@ -1,5 +1,12 @@
 package ch.silviowangler.map4j.mapstruct;
 
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -12,22 +19,63 @@ public final class MapperRegistry
 {
 
    private Map<CombinedClassKey, BiFunction> mappers = new HashMap<> ();
+   private Map<CombinedClassKey, Class<? extends  BaseMapper>> baseMappers = new HashMap<> ();
+   private Map<CombinedClassKey, Class<? extends  InverseBaseMapper>> inverseBaseMappers = new HashMap<> ();
 
-   public void addMapping (Class aClass, Class bClass, BiFunction function)
-   {
+
+   public void addMapping (Class aClass, Class bClass, BiFunction function) {
+      final CombinedClassKey combinedClassKey = new CombinedClassKey (aClass, bClass);
+      checkAlreadyMappingDefined(combinedClassKey);
       mappers.put (new CombinedClassKey (aClass, bClass), function);
    }
 
-   public <T> BiFunction resolveConsumer (Class<?> sourceClass, Class<T> targetClass)
-   {
-
+   public BiFunction resolveConsumer (Class sourceClass, Class targetClass) {
       final CombinedClassKey combinedClassKey = new CombinedClassKey (sourceClass, targetClass);
-
       NoSuchMappingException ex = new NoSuchMappingException ("No such mapping for source class " + combinedClassKey.getA ().getSimpleName () + " and target class "
                + combinedClassKey.getB ().getSimpleName (), combinedClassKey.getA (), combinedClassKey.getB ());
-
       BiFunction c = Optional.of (mappers.get (combinedClassKey)).orElseThrow ( () -> ex);
-
       return c;
    }
+
+   public void addBaseMapping(Class source, Class target, Class<? extends BaseMapper> baseMapper) {
+      final CombinedClassKey combinedClassKey = new CombinedClassKey (source, target);
+      checkAlreadyMappingDefined(combinedClassKey);
+      baseMapper.getInterfaces();
+      baseMappers.put (combinedClassKey, baseMapper);
+   }
+
+   public void addInverseBaseMapping(Class source, Class target, Class<? extends InverseBaseMapper> inverseBaseMapper) {
+      final CombinedClassKey combinedClassKey = new CombinedClassKey (source, target);
+      checkAlreadyMappingDefined(combinedClassKey);
+      baseMappers.put (combinedClassKey, inverseBaseMapper);
+      final CombinedClassKey combinedClassKeyInverse = new CombinedClassKey (target, source);
+      checkAlreadyMappingDefined(combinedClassKeyInverse);
+      inverseBaseMappers.put (combinedClassKeyInverse, inverseBaseMapper);
+   }
+
+   private <S, T> void checkAlreadyMappingDefined(CombinedClassKey combinedClassKey) {
+      if(mappers.containsKey(combinedClassKey) || baseMappers.containsKey(combinedClassKey) || inverseBaseMappers.containsKey(combinedClassKey)) {
+         throw new IllegalArgumentException("Mapping is already defined for source class " + combinedClassKey.getA ().getSimpleName () + " and target class "
+                 + combinedClassKey.getB ().getSimpleName ());
+      }
+   }
+
+   public BaseMapper resolveBaseMapper(Class sourceClass, Class targetClass) {
+      final CombinedClassKey combinedClassKey = new CombinedClassKey (sourceClass, targetClass);
+      Class<? extends BaseMapper> basemapperClass = baseMappers.get(combinedClassKey);
+      if(basemapperClass != null) {
+         return Mappers.getMapper(basemapperClass);
+      }
+      return null;
+   }
+
+   public InverseBaseMapper resolveInverseMapper(Class<?> sourceClass, Class targetClass) {
+      final CombinedClassKey combinedClassKey = new CombinedClassKey (sourceClass, targetClass);
+      Class<? extends InverseBaseMapper> inverseBasemapperClass = inverseBaseMappers.get(combinedClassKey);
+      if(inverseBasemapperClass != null) {
+         return Mappers.getMapper(inverseBasemapperClass);
+      }
+      return null;
+   }
+
 }

--- a/map4j-mapstruct/mapstruct/src/main/java/ch/silviowangler/map4j/mapstruct/MapperRegistry.java
+++ b/map4j-mapstruct/mapstruct/src/main/java/ch/silviowangler/map4j/mapstruct/MapperRegistry.java
@@ -22,21 +22,37 @@ public final class MapperRegistry
    private Map<CombinedClassKey, Class<? extends  BaseMapper>> baseMappers = new HashMap<> ();
    private Map<CombinedClassKey, Class<? extends  InverseBaseMapper>> inverseBaseMappers = new HashMap<> ();
 
-
+   /**
+    * Add a mappingfunction to the registry for a mapping from aClass to bClass.
+    * Your have to define the BiFunction by your own.
+    * @param aClass the source object to map from
+    * @param bClass the target object to map to
+    * @param function this function will be called for mapping
+    */
    public void addMapping (Class aClass, Class bClass, BiFunction function) {
       final CombinedClassKey combinedClassKey = new CombinedClassKey (aClass, bClass);
       checkAlreadyMappingDefined(combinedClassKey);
       mappers.put (new CombinedClassKey (aClass, bClass), function);
    }
 
+   /**
+    * Resolve the mapping function to map from sourceClass to targetClass
+    * @param sourceClass to map from
+    * @param targetClass to map to
+    * @return the function for the specific mapping
+    */
    public BiFunction resolveConsumer (Class sourceClass, Class targetClass) {
       final CombinedClassKey combinedClassKey = new CombinedClassKey (sourceClass, targetClass);
-      NoSuchMappingException ex = new NoSuchMappingException ("No such mapping for source class " + combinedClassKey.getA ().getSimpleName () + " and target class "
-               + combinedClassKey.getB ().getSimpleName (), combinedClassKey.getA (), combinedClassKey.getB ());
-      BiFunction c = Optional.of (mappers.get (combinedClassKey)).orElseThrow ( () -> ex);
-      return c;
+      return mappers.get (combinedClassKey);
    }
 
+   /**
+    * Adds a BaseMapper to map from source to target. It is not possible to map from target back to source.
+    * Use an InverseBaseMapper instead in this case.
+    * @param source to map from
+    * @param target to map to
+    * @param baseMapper the mapper for this two objects to map
+    */
    public void addBaseMapping(Class source, Class target, Class<? extends BaseMapper> baseMapper) {
       final CombinedClassKey combinedClassKey = new CombinedClassKey (source, target);
       checkAlreadyMappingDefined(combinedClassKey);
@@ -44,6 +60,13 @@ public final class MapperRegistry
       baseMappers.put (combinedClassKey, baseMapper);
    }
 
+   /**
+    * Adds a InverseBaseMapper to map from source to target and also a inverse mapping back form target to source.
+    *
+    * @param source to map from
+    * @param target to map to
+    * @param inverseBaseMapper the mapper for this two objects to map forward and inverse
+    */
    public void addInverseBaseMapping(Class source, Class target, Class<? extends InverseBaseMapper> inverseBaseMapper) {
       final CombinedClassKey combinedClassKey = new CombinedClassKey (source, target);
       checkAlreadyMappingDefined(combinedClassKey);
@@ -51,13 +74,6 @@ public final class MapperRegistry
       final CombinedClassKey combinedClassKeyInverse = new CombinedClassKey (target, source);
       checkAlreadyMappingDefined(combinedClassKeyInverse);
       inverseBaseMappers.put (combinedClassKeyInverse, inverseBaseMapper);
-   }
-
-   private <S, T> void checkAlreadyMappingDefined(CombinedClassKey combinedClassKey) {
-      if(mappers.containsKey(combinedClassKey) || baseMappers.containsKey(combinedClassKey) || inverseBaseMappers.containsKey(combinedClassKey)) {
-         throw new IllegalArgumentException("Mapping is already defined for source class " + combinedClassKey.getA ().getSimpleName () + " and target class "
-                 + combinedClassKey.getB ().getSimpleName ());
-      }
    }
 
    public BaseMapper resolveBaseMapper(Class sourceClass, Class targetClass) {
@@ -77,5 +93,13 @@ public final class MapperRegistry
       }
       return null;
    }
+
+   private <S, T> void checkAlreadyMappingDefined(CombinedClassKey combinedClassKey) {
+      if(mappers.containsKey(combinedClassKey) || baseMappers.containsKey(combinedClassKey) || inverseBaseMappers.containsKey(combinedClassKey)) {
+         throw new IllegalArgumentException("Mapping is already defined for source class " + combinedClassKey.getA ().getSimpleName () + " and target class "
+                 + combinedClassKey.getB ().getSimpleName ());
+      }
+   }
+
 
 }

--- a/map4j-mapstruct/mapstruct/src/test/java/ch/silviowangler/map4j/mapstruct/AdresseMapperTest.java
+++ b/map4j-mapstruct/mapstruct/src/test/java/ch/silviowangler/map4j/mapstruct/AdresseMapperTest.java
@@ -1,0 +1,84 @@
+package ch.silviowangler.map4j.mapstruct;
+
+import ch.silviowangler.map4j.AdresseDTO;
+import ch.silviowangler.map4j.AdresseVO;
+import ch.silviowangler.map4j.PartnerDTO;
+import ch.silviowangler.map4j.PartnerVO;
+import ch.silviowangler.map4j.mapstruct.mappers.AdresseMapper;
+import ch.silviowangler.map4j.mapstruct.mappers.PartnerMapper;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+
+
+/**
+ * Created by Silvio Wangler on 15/04/16.
+ */
+public class AdresseMapperTest {
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void mapAdresseDtoToAdresseVOInverse() {
+        MapperRegistry registry = new MapperRegistry();
+
+        registry.addInverseBaseMapping(AdresseVO.class, AdresseDTO.class, AdresseMapper.class);
+        MapStructMapper mapper = new MapStructMapper(registry);
+
+        AdresseDTO adresseDTO = new AdresseDTO("Haupstrasse", "4", "9001", "St. Gallen");
+        AdresseVO adresseVO = mapper.map(adresseDTO, AdresseVO.class);
+
+        assertEquals( adresseDTO.getStrasse(), adresseVO.getStreet());
+        assertEquals( adresseDTO.getHausnummer(), String.valueOf(adresseVO.getNumber()));
+        assertEquals( adresseDTO.getPlz(), adresseVO.getPlz());
+        assertEquals( adresseDTO.getOrt(), adresseVO.getTown());
+    }
+
+
+    @Test
+    public void checkNoSuchMappingExceptionIsThrown() {
+        MapperRegistry registry = new MapperRegistry();
+        MapStructMapper mapper = new MapStructMapper(registry);
+        AdresseDTO adresseDTO = new AdresseDTO("Haupstrasse", "4", "9001", "St. Gallen");
+
+        exception.expect(NoSuchMappingException.class);
+        AdresseVO adresseVO = mapper.map(adresseDTO, AdresseVO.class);
+    }
+
+    @Test
+    public void checkMappingAlreadyRegisteredExceptionIsThrown() {
+        MapperRegistry registry = new MapperRegistry();
+        registry.addBaseMapping(AdresseVO.class, AdresseDTO.class, AdresseMapper.class);
+        exception.expect(IllegalArgumentException.class);
+        registry.addInverseBaseMapping(AdresseVO.class, AdresseDTO.class, AdresseMapper.class);
+    }
+
+    @Test
+    public void checkMappingAlreadyRegisteredExceptionIsThrown2() {
+        MapperRegistry registry = new MapperRegistry();
+        registry.addInverseBaseMapping(AdresseVO.class, AdresseDTO.class, AdresseMapper.class);
+        exception.expect(IllegalArgumentException.class);
+        registry.addBaseMapping(AdresseVO.class, AdresseDTO.class, AdresseMapper.class);
+    }
+
+    @Test
+    public void checkMappingAlreadyRegisteredExceptionIsThrown3() {
+        MapperRegistry registry = new MapperRegistry();
+        registry.addInverseBaseMapping(AdresseVO.class, AdresseDTO.class, AdresseMapper.class);
+        exception.expect(IllegalArgumentException.class);
+        registry.addMapping(AdresseVO.class, AdresseDTO.class, (a, b) ->  {
+            if (b == null) {
+                return AdresseMapper.INSTANCE.createFromSource((AdresseVO) a);
+            }
+            throw new NotImplementedException();
+        });
+        ;
+    }
+
+}

--- a/map4j-mapstruct/mapstruct/src/test/java/ch/silviowangler/map4j/mapstruct/PartnerMapperTest.java
+++ b/map4j-mapstruct/mapstruct/src/test/java/ch/silviowangler/map4j/mapstruct/PartnerMapperTest.java
@@ -1,14 +1,13 @@
 package ch.silviowangler.map4j.mapstruct;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.Date;
-
-import org.junit.Test;
-
 import ch.silviowangler.map4j.PartnerDTO;
 import ch.silviowangler.map4j.PartnerVO;
 import ch.silviowangler.map4j.mapstruct.mappers.PartnerMapper;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
 
 
 /**
@@ -17,7 +16,7 @@ import ch.silviowangler.map4j.mapstruct.mappers.PartnerMapper;
 public class PartnerMapperTest {
 
     @Test
-    public void mapPartnerDtoToPartnerVO() {
+    public void mapPartnerDtoToPartnerVOBiFunction() {
 
         MapperRegistry registry = new MapperRegistry();
 
@@ -36,6 +35,34 @@ public class PartnerMapperTest {
         );
 
 
+        MapStructMapper mapper = new MapStructMapper(registry);
+
+        PartnerVO partnerVO = new PartnerVO("Silvio", "Wangler", new Date(), "+41 44 444 44 44");
+
+        PartnerDTO partnerDTO = mapper.map(partnerVO, PartnerDTO.class);
+
+        assertEquals( partnerDTO.getVorname(), partnerVO.getFirstname());
+        assertEquals( partnerDTO.getNachname(), partnerVO.getLastname());
+        assertEquals( partnerDTO.getTelephone(), partnerVO.getTelephone());
+        assertEquals( partnerDTO.getGeburtstag(), partnerVO.getBirthdate());
+
+
+        PartnerDTO partnerDTO1 = new PartnerDTO();
+
+        mapper.map(partnerVO, partnerDTO1);
+
+        assertEquals( partnerDTO1.getVorname(), partnerVO.getFirstname());
+        assertEquals( partnerDTO1.getNachname(), partnerVO.getLastname());
+        assertEquals( partnerDTO1.getTelephone(), partnerVO.getTelephone());
+        assertEquals( partnerDTO1.getGeburtstag(), partnerVO.getBirthdate());
+    }
+
+    @Test
+    public void mapPartnerDtoToPartnerVOBaseMapper() {
+
+        MapperRegistry registry = new MapperRegistry();
+
+        registry.addBaseMapping(PartnerVO.class, PartnerDTO.class, PartnerMapper.class);
         MapStructMapper mapper = new MapStructMapper(registry);
 
         PartnerVO partnerVO = new PartnerVO("Silvio", "Wangler", new Date(), "+41 44 444 44 44");

--- a/map4j-mapstruct/mapstruct/src/test/java/ch/silviowangler/map4j/mapstruct/mappers/AdresseMapper.java
+++ b/map4j-mapstruct/mapstruct/src/test/java/ch/silviowangler/map4j/mapstruct/mappers/AdresseMapper.java
@@ -1,0 +1,40 @@
+package ch.silviowangler.map4j.mapstruct.mappers;
+
+import ch.silviowangler.map4j.AdresseDTO;
+import ch.silviowangler.map4j.AdresseVO;
+import ch.silviowangler.map4j.PartnerDTO;
+import ch.silviowangler.map4j.PartnerVO;
+import ch.silviowangler.map4j.mapstruct.BaseMapper;
+import ch.silviowangler.map4j.mapstruct.InverseBaseMapper;
+import org.mapstruct.InheritConfiguration;
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.Mappings;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Created by Silvio Wangler on 15/04/16.
+ */
+@Mapper
+public interface AdresseMapper extends InverseBaseMapper<AdresseVO, AdresseDTO>
+{
+
+   AdresseMapper INSTANCE = Mappers.getMapper(AdresseMapper.class);
+
+   @Override
+   @Mapping(source = "street", target = "strasse")
+   @Mapping(source = "number", target = "hausnummer")
+   @Mapping(source = "town", target = "ort")
+   AdresseDTO createFromSource(AdresseVO source);
+
+   @Override
+   @InheritInverseConfiguration(name="createFromSource")
+   AdresseVO createFromSourceInverse(AdresseDTO source);
+
+
+   @Override
+   @InheritConfiguration(name="createFromSource")
+   void updateFromSource(AdresseVO source, @MappingTarget AdresseDTO target);
+}

--- a/map4j-testutil/src/main/java/ch/silviowangler/map4j/AdresseDTO.java
+++ b/map4j-testutil/src/main/java/ch/silviowangler/map4j/AdresseDTO.java
@@ -1,0 +1,54 @@
+package ch.silviowangler.map4j;
+
+/**
+ * Created by Silvio Wangler on 17/03/16.
+ */
+public class AdresseDTO {
+
+    private String strasse;
+    private String hausnummer;
+    private String plz;
+    private String ort;
+
+    public AdresseDTO() {
+    }
+
+    public AdresseDTO(String strasse, String hausnummer, String plz, String ort) {
+        this.strasse = strasse;
+        this.hausnummer = hausnummer;
+        this.plz = plz;
+        this.ort = ort;
+    }
+
+    public String getStrasse() {
+        return strasse;
+    }
+
+    public void setStrasse(String strasse) {
+        this.strasse = strasse;
+    }
+
+    public String getHausnummer() {
+        return hausnummer;
+    }
+
+    public void setHausnummer(String hausnummer) {
+        this.hausnummer = hausnummer;
+    }
+
+    public String getPlz() {
+        return plz;
+    }
+
+    public void setPlz(String plz) {
+        this.plz = plz;
+    }
+
+    public String getOrt() {
+        return ort;
+    }
+
+    public void setOrt(String ort) {
+        this.ort = ort;
+    }
+}

--- a/map4j-testutil/src/main/java/ch/silviowangler/map4j/AdresseVO.java
+++ b/map4j-testutil/src/main/java/ch/silviowangler/map4j/AdresseVO.java
@@ -1,0 +1,56 @@
+package ch.silviowangler.map4j;
+
+import java.util.Date;
+
+/**
+ * Created by Silvio Wangler on 17/03/16.
+ */
+public class AdresseVO {
+
+    private String street;
+    private int number;
+    private String plz;
+    private String town;
+
+    public AdresseVO() {
+    }
+
+    public AdresseVO(String street, int number, String plz, String town) {
+        this.street = street;
+        this.number = number;
+        this.plz = plz;
+        this.town = town;
+    }
+
+    public String getStreet() {
+        return street;
+    }
+
+    public void setStreet(String street) {
+        this.street = street;
+    }
+
+    public int getNumber() {
+        return number;
+    }
+
+    public void setNumber(int number) {
+        this.number = number;
+    }
+
+    public String getPlz() {
+        return plz;
+    }
+
+    public void setPlz(String plz) {
+        this.plz = plz;
+    }
+
+    public String getTown() {
+        return town;
+    }
+
+    public void setTown(String town) {
+        this.town = town;
+    }
+}


### PR DESCRIPTION
- MapStruct Verion 1.1.0
- InverseBaseMapper, der vorwärts und wieder zurück mappen kann zwischen zwei Objekten
- MapperRegistry erweitern, um Mapper einfacher zu registrieren. 
- Update Gradle 3.2.1